### PR TITLE
Bug/301 upload memory exhausted

### DIFF
--- a/src/Controller/Api/Cas/CasController.php
+++ b/src/Controller/Api/Cas/CasController.php
@@ -7,8 +7,11 @@ use App\Entity\Cas\CasLink;
 use App\Service\CasService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -313,10 +316,28 @@ class CasController extends AbstractController
 		return new Response(null, 204);
 	}
 
+	/**
+	 * Bulk-create CAS links from an uploaded CSV.
+	 * @param Request $request
+	 * @return Response
+	 *
+	 * #[Autowire(service: 'doctrine.debug_data_holder')] — Symfony doesn’t type-hint this service by default, so this attribute says “inject that specific service.”
+	 * @var DebugDataHolder $debugDataHolder = null — optional. In dev you get the holder and can $debugDataHolder->reset() after each batch. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
+	 * Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev.
+	 */
 	#[Route('/links/upload', methods: ['POST'])]
 	#[IsGranted(new Expression('is_granted("ROLE_GLOBAL_ADMIN") or is_granted("ROLE_CAS_ADMIN")'))]
-	public function postLinkBulkAction(Request $request): Response
-	{
+	public function postLinkBulkAction(
+		Request $request,
+		?Profiler $profiler = null,
+		#[Autowire(service: 'doctrine.debug_data_holder')]
+		?DebugDataHolder $debugDataHolder = null,
+	): Response {
+		// Profiler and Doctrine's debug query holder retain every SQL (+ backtrace) for
+		// the whole request. Disabling/resetting them is required for large CSVs (DEV only; this does nothing in PROD).
+		$profiler?->disable();
+		$debugDataHolder?->reset();
+
 		$uploadedFile = $request->files->get('csv');
 		if (!$uploadedFile) {
 			return new Response(json_encode("No CSV file provided."), 400, ["Content-Type" => "application/json"]);
@@ -403,16 +424,19 @@ class CasController extends AbstractController
 				
 				$rowsSinceLastClear++;
 				if ($rowsSinceLastClear >= 50) {
-					$this->em->flush(); // flush the entity manager after 50 links to avoid memory issues.
-					$this->em->clear(); // clear the entity manager after 50 links to avoid memory issues.
-					$cycle = $this->em->getReference(CasCycle::class, $cycleId); // clear() detaches everything from Doctrine, so we need to re-attach the cycle.
+					// Clear EM + wipe debug query/backtrace buffer every 50 rows.
+					$this->em->flush();
+					$this->em->clear();
+					$debugDataHolder?->reset();
+					$cycle = $this->em->getReference(CasCycle::class, $cycleId); // clear() detaches everything, so re-attach the cycle.
 					$rowsSinceLastClear = 0;
 				}
 			}
 		}
 
 		$this->em->flush();
-		$this->em->clear(); // clear the entity manager after the last batch to avoid memory issues.
+		$this->em->clear();
+		$debugDataHolder?->reset();
 
 		return new Response(
 			sprintf('%d added. %d rejected: %s', $added, $rejected, implode(', ', $rejectedArr)),

--- a/src/Controller/Api/CrimeLog/CrimeLogController.php
+++ b/src/Controller/Api/CrimeLog/CrimeLogController.php
@@ -7,9 +7,12 @@ use App\Entity\CrimeLog\FireLog;
 use App\Service\CrimeLogService;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -45,10 +48,23 @@ class CrimeLogController extends AbstractController
 	 * Updates the crimelog from the specified request.
 	 * @param Request $request The holder of the information about the updated crimelog.
 	 * @return Response The crimelog, the status code, and the HTTP headers.
+	 *
+	 * #[Autowire(service: 'doctrine.debug_data_holder')] — Symfony doesn’t type-hint this service by default, so this attribute says “inject that specific service.”
+	 * @var DebugDataHolder $debugDataHolder = null — optional. In dev you get the holder and can $debugDataHolder->reset() after each batch. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
+	 * Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev.
 	 */
 	#[Route('upload', methods: ['POST'])]
-	public function postCrimeLogBulkAction(Request $request): Response
-	{
+	public function postCrimeLogBulkAction(
+		Request $request,
+		?Profiler $profiler = null,
+		#[Autowire(service: 'doctrine.debug_data_holder')]
+		?DebugDataHolder $debugDataHolder = null,
+	): Response {
+		// Profiler and Doctrine's debug query holder retain every SQL (+ backtrace) for
+		// the whole request. Disabling/resetting them is required for large CSVs (DEV only; this does nothing in PROD).
+		$profiler?->disable();
+		$debugDataHolder?->reset();
+
 		$file = file($request->files->get('csv'));
 
 		$csvFile = array_map('str_getcsv', $file);
@@ -82,13 +98,16 @@ class CrimeLogController extends AbstractController
 
 				$rowsSinceLastClear++;
 				if ($rowsSinceLastClear >= 50) {
+					// Clear EM + wipe debug query/backtrace buffer every 50 rows.
 					$this->em->flush();
 					$this->em->clear();
+					$debugDataHolder?->reset();
 					$rowsSinceLastClear = 0;
 				}
 			}
 			$this->em->flush();
 			$this->em->clear();
+			$debugDataHolder?->reset();
 		}
 
 		if ($rejected === 0) {

--- a/src/Controller/Api/Programs/ProgramsController.php
+++ b/src/Controller/Api/Programs/ProgramsController.php
@@ -10,9 +10,12 @@ use App\Service\ProgramsService;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -494,11 +497,24 @@ class ProgramsController extends AbstractController
 	 * CSV columns: keyword (required), program_id (optional).
 	 * @param Request $request
 	 * @return Response
+	 *
+	 * #[Autowire(service: 'doctrine.debug_data_holder')] — Symfony doesn’t type-hint this service by default, so this attribute says “inject that specific service.”
+	 * @var DebugDataHolder $debugDataHolder = null — optional. In dev you get the holder and can $debugDataHolder->reset() after each batch. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
+	 * Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev.
 	 */
 	#[Route('/keywords/upload', methods: ['POST'])]
 	#[IsGranted(new Expression('is_granted("ROLE_GLOBAL_ADMIN") or is_granted("ROLE_PROGRAMS_ADMIN") or is_granted("ROLE_PROGRAMS_CREATE")'))]
-	public function postKeywordBulkAction(Request $request): Response
-	{
+	public function postKeywordBulkAction(
+		Request $request,
+		?Profiler $profiler = null,
+		#[Autowire(service: 'doctrine.debug_data_holder')]
+		?DebugDataHolder $debugDataHolder = null,
+	): Response {
+		// Profiler and Doctrine's debug query holder retain every SQL (+ backtrace) for
+		// the whole request. Disabling/resetting them is required for large CSVs (DEV only; this does nothing in PROD).
+		$profiler?->disable();
+		$debugDataHolder?->reset();
+
 		$uploaded = $request->files->get('csv');
 		if (!$uploaded) {
 			return new Response("No CSV file was uploaded.", 422, array("Content-Type" => "application/json"));
@@ -520,7 +536,7 @@ class ProgramsController extends AbstractController
 			$rows[] = array_combine($headers, $row);
 		}
 
-		$result = $this->service->bulkCreateKeywords($rows);
+		$result = $this->service->bulkCreateKeywords($rows, $debugDataHolder);
 
 		// Keyword names originate from the uploaded CSV and are rendered via v-html
 		// on the client, so HTML-encode each before embedding to prevent stored/reflected XSS.

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -455,16 +455,20 @@ class RedirectController extends AbstractController
     {
         // Profiler retains every Doctrine query for the whole request; disable for large CSVs.
         $profiler?->disable();
+        // Symfony + per-row UniqueEntity queries exceed the default 128M near ~750 rows.
+        // ini_set('memory_limit', '256M');
 
         $file = file($request->files->get('csv'));
 
         $csvFile = array_map('str_getcsv', $file);
+        unset($file);
         $headers = array_shift($csvFile);
 
         $csv    = array();
         foreach ($csvFile as $row) {
             $csv[] = array_combine($headers, $row);
         }
+        unset($csvFile);
 
         $added = 0;
         $rejected = 0;
@@ -472,14 +476,10 @@ class RedirectController extends AbstractController
         $rejectedArr = [];
 
         if (count($csv) > 0) {
-            $rowsSinceLastClear = 0;
             foreach ($csv as $redirect) {
                 $statusCode = $this->_addRedirect($redirect);
-                $rowsSinceLastClear++;
-                if ($rowsSinceLastClear >= 50) {
-                    $this->em->clear(); // clear the entity manager after 50 redirects to avoid memory issues.
-                    $rowsSinceLastClear = 0;
-                }
+                // Clear every row — UniqueEntity lookups also load entities into the EM.
+                $this->em->clear();
                 switch ($statusCode) {
                     case 201:
                         ++$added;
@@ -491,7 +491,6 @@ class RedirectController extends AbstractController
                         break;
                 }
             }
-            $this->em->clear(); // clear the entity manager after the last batch to avoid memory issues.
         }
 
         return new Response(sprintf('%d added.<br>%d rejected or skipped (from_link):<br><ul><li>%s</li></ul>', $added, $rejected, implode('</li><li>', $rejectedArr)), 201, array("Content-Type" => "application/json"));
@@ -575,7 +574,6 @@ class RedirectController extends AbstractController
 
         $this->em->persist($redirect); // Persist the redirect.
         $this->em->flush(); // Commit everything to the database.
-        // em->clear() done in batches in the postRedirectBulkAction method.
 
         return 201;
     }

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -459,6 +459,10 @@ class RedirectController extends AbstractController
      * Updates the redirect from the specified request.
      * @param Request $request The holder of the information about the updated redirect.
      * @return Response The redirect, the status code, and the HTTP headers.
+     * 
+     * #[Autowire(service: 'doctrine.debug_data_holder')] — Symfony doesn’t type-hint this service by default, so this attribute says “inject that specific service.”
+     * @var DebugDataHolder $debugDataHolder = null — optional. In dev you get the holder and can $debugDataHolder->reset() after each row. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
+     * Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev.
      */
     #[Route('upload', methods: ['POST'])]
     public function postRedirectBulkAction(
@@ -468,21 +472,19 @@ class RedirectController extends AbstractController
         ?DebugDataHolder $debugDataHolder = null,
     ): Response {
         // Profiler and Doctrine's debug query holder retain every SQL (+ backtrace) for
-        // the whole request. Disabling/resetting them is required for large CSVs in dev.
+        // the whole request. Disabling/resetting them is required for large CSVs (DEV only; this does nothing in PROD).
         $profiler?->disable();
         $debugDataHolder?->reset();
 
         $file = file($request->files->get('csv'));
 
         $csvFile = array_map('str_getcsv', $file);
-        unset($file);
         $headers = array_shift($csvFile);
 
         $csv    = array();
         foreach ($csvFile as $row) {
             $csv[] = array_combine($headers, $row);
         }
-        unset($csvFile);
 
         $added = 0;
         $rejected = 0;
@@ -508,11 +510,8 @@ class RedirectController extends AbstractController
             }
         }
 
-        // Free bulk working set before kernel terminate / error handlers run.
-        unset($csv);
         $this->em->clear();
         $debugDataHolder?->reset();
-        gc_collect_cycles();
 
         if ($rejected === 0) {
             $message = sprintf('%d added.<br>0 rejected or skipped.', $added);
@@ -524,7 +523,6 @@ class RedirectController extends AbstractController
                 implode('</li><li>', $rejectedArr)
             );
         }
-        unset($rejectedArr);
 
         return new Response($message, 201, array("Content-Type" => "application/json"));
     }

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -6,6 +6,8 @@ use App\Entity\Redirect\Redirect;
 use App\Service\RedirectService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
@@ -459,11 +461,16 @@ class RedirectController extends AbstractController
      * @return Response The redirect, the status code, and the HTTP headers.
      */
     #[Route('upload', methods: ['POST'])]
-    public function postRedirectBulkAction(Request $request, ?Profiler $profiler = null): Response
-    {
-        // Profiler retains every Doctrine query for the whole request; disable for large CSVs.
+    public function postRedirectBulkAction(
+        Request $request,
+        ?Profiler $profiler = null,
+        #[Autowire(service: 'doctrine.debug_data_holder')]
+        ?DebugDataHolder $debugDataHolder = null,
+    ): Response {
+        // Profiler and Doctrine's debug query holder retain every SQL (+ backtrace) for
+        // the whole request. Disabling/resetting them is required for large CSVs in dev.
         $profiler?->disable();
-        // Symfony + per-row UniqueEntity queries exceed the default 128M near ~750 rows.
+        $debugDataHolder?->reset();
         ini_set('memory_limit', '256M');
 
         $file = file($request->files->get('csv'));
@@ -486,8 +493,9 @@ class RedirectController extends AbstractController
         if (count($csv) > 0) {
             foreach ($csv as $redirect) {
                 $statusCode = $this->_addRedirect($redirect);
-                // Clear every row — UniqueEntity lookups also load entities into the EM.
+                // Clear EM + wipe debug query/backtrace buffer every row.
                 $this->em->clear();
+                $debugDataHolder?->reset();
                 switch ($statusCode) {
                     case 201:
                         ++$added;

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -471,7 +471,6 @@ class RedirectController extends AbstractController
         // the whole request. Disabling/resetting them is required for large CSVs in dev.
         $profiler?->disable();
         $debugDataHolder?->reset();
-        ini_set('memory_limit', '256M');
 
         $file = file($request->files->get('csv'));
 
@@ -509,7 +508,25 @@ class RedirectController extends AbstractController
             }
         }
 
-        return new Response(sprintf('%d added.<br>%d rejected or skipped (from_link):<br><ul><li>%s</li></ul>', $added, $rejected, implode('</li><li>', $rejectedArr)), 201, array("Content-Type" => "application/json"));
+        // Free bulk working set before kernel terminate / error handlers run.
+        unset($csv);
+        $this->em->clear();
+        $debugDataHolder?->reset();
+        gc_collect_cycles();
+
+        if ($rejected === 0) {
+            $message = sprintf('%d added.<br>0 rejected or skipped.', $added);
+        } else {
+            $message = sprintf(
+                '%d added.<br>%d rejected or skipped (from_link):<br><ul><li>%s</li></ul>',
+                $added,
+                $rejected,
+                implode('</li><li>', $rejectedArr)
+            );
+        }
+        unset($rejectedArr);
+
+        return new Response($message, 201, array("Content-Type" => "application/json"));
     }
 
     /**

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -450,8 +451,11 @@ class RedirectController extends AbstractController
      * @return Response The redirect, the status code, and the HTTP headers.
      */
     #[Route('upload', methods: ['POST'])]
-    public function postRedirectBulkAction(Request $request): Response
+    public function postRedirectBulkAction(Request $request, ?Profiler $profiler = null): Response
     {
+        // Profiler retains every Doctrine query for the whole request; disable for large CSVs.
+        $profiler?->disable();
+
         $file = file($request->files->get('csv'));
 
         $csvFile = array_map('str_getcsv', $file);
@@ -470,13 +474,13 @@ class RedirectController extends AbstractController
         if (count($csv) > 0) {
             $rowsSinceLastClear = 0;
             foreach ($csv as $redirect) {
-                $newRedirect = $this->_addRedirect($redirect);
+                $statusCode = $this->_addRedirect($redirect);
                 $rowsSinceLastClear++;
                 if ($rowsSinceLastClear >= 50) {
                     $this->em->clear(); // clear the entity manager after 50 redirects to avoid memory issues.
                     $rowsSinceLastClear = 0;
                 }
-                switch ($newRedirect->getStatusCode()) {
+                switch ($statusCode) {
                     case 201:
                         ++$added;
                         break;
@@ -493,12 +497,16 @@ class RedirectController extends AbstractController
         return new Response(sprintf('%d added.<br>%d rejected or skipped (from_link):<br><ul><li>%s</li></ul>', $added, $rejected, implode('</li><li>', $rejectedArr)), 201, array("Content-Type" => "application/json"));
     }
 
-    private function _addRedirect($data): Response
+    /**
+     * Persist one redirect row from a bulk CSV upload.
+     * Returns an HTTP-style status code (201 created, 422 rejected).
+     * Skips remote get_headers() checks — too expensive for bulk imports.
+     */
+    private function _addRedirect(array $data): int
     {
         $from = $data['from_link'];
         $type = $data['item_type'];
         $to = $data['to_link'];
-
 
         $redirect = new Redirect();
 
@@ -551,37 +559,17 @@ class RedirectController extends AbstractController
         $errors = $this->service->validate($redirect); // Validate the redirect.
 
         if (count($errors) > 0) {
-            // Do the following if there is more than one error.
-            $serialized = $this->serializer->serialize($errors, "json", ['groups' => 'redir']);
-
-            return new Response($serialized, 422, array("Content-Type" => "application/json"));
+            return 422;
         }
 
-        /* Validation of toLink */
+        /* Local toLink checks only (no remote get_headers in bulk). */
 
         if (
             $redirect->getItemType() != "invalid redirect of broken link"
             && $redirect->getItemType() != "invalid redirect of shortened link"
         ) {
-            // Check if the toLink is a valid URL if it is supposed to be a valid redirect.
-            $fullToLink = $toLink[0] == "/" ? "https://www.emich.edu$toLink" : $toLink;
-
-            if (get_headers($fullToLink, 1)[0] == "HTTP/1.1 404 Not Found") {
-                $message = $redirect->getItemType() == "redirect of broken link"
-                    ? "The actual link is not valid." : "The full link is not valid.";
-                $response = new Response($message, 422, array("Content-Type" => "application/json"));
-
-                return $response;
-            }
-
             if ($toLink != trim($toLink)) {
-                // Check if the toLink has any spaces.
-                $message = $redirect->getItemType() == "redirect of broken link"
-                    ? "The actual link should not include any spaces." : "The full link should not include any spaces.";
-
-                $response = new Response($message, 422, array("Content-Type" => "application/json"));
-
-                return $response;
+                return 422;
             }
         }
 
@@ -589,8 +577,6 @@ class RedirectController extends AbstractController
         $this->em->flush(); // Commit everything to the database.
         // em->clear() done in batches in the postRedirectBulkAction method.
 
-        $serialized = $this->serializer->serialize($redirect, "json", ['groups' => 'redir']);
-
-        return new Response($serialized, 201, array("Content-Type" => "application/json"));
+        return 201;
     }
 }

--- a/src/Controller/Api/Redirect/RedirectController.php
+++ b/src/Controller/Api/Redirect/RedirectController.php
@@ -302,17 +302,21 @@ class RedirectController extends AbstractController
         $toLink = substr($toLink, -1) == "/" ? substr($toLink, 0, -1) : $toLink; // Remove "/" if it is the last character.
         $parsedToLink = parse_url($toLink);
 
-        if (array_key_exists("host", $parsedToLink)
+        if (
+            array_key_exists("host", $parsedToLink)
             && array_key_exists("path", $parsedToLink)
-            && (($parsedToLink["host"] == "www.emich.edu") || ($parsedToLink["host"] == "emich.edu"))) {
+            && (($parsedToLink["host"] == "www.emich.edu") || ($parsedToLink["host"] == "emich.edu"))
+        ) {
             if ($parsedToLink["path"][0] != "/") {
                 $toLink = "/" . $parsedToLink["path"];
             } else {
                 $toLink = $parsedToLink["path"];
             }
-        } else if (!array_key_exists("host", $parsedToLink)
+        } else if (
+            !array_key_exists("host", $parsedToLink)
             && array_key_exists("path", $parsedToLink)
-            && $parsedToLink["path"][0] != "/") {
+            && $parsedToLink["path"][0] != "/"
+        ) {
             $toLink = "/" . $parsedToLink["path"];
         }
 
@@ -330,10 +334,12 @@ class RedirectController extends AbstractController
             return new Response($serialized, 422, array("Content-Type" => "application/json"));
         }
 
-        if ($redirect->getItemType() != "invalid redirect of broken link"
+        if (
+            $redirect->getItemType() != "invalid redirect of broken link"
             && $redirect->getItemType() != "invalid redirect of shortened link"
             && $redirect->getItemType() != "expired redirect of broken link"
-            && $redirect->getItemType() != "expired redirect of shortened link") {
+            && $redirect->getItemType() != "expired redirect of shortened link"
+        ) {
             // Check if the toLink is a valid URL if it is supposed to be a valid redirect.
             $fullToLink = $toLink[0] == "/" ? "https://www.emich.edu$toLink" : $toLink;
 
@@ -352,8 +358,10 @@ class RedirectController extends AbstractController
 
                 return new Response($message, 422, array("Content-Type" => "application/json"));
             }
-        } else if ($redirect->getItemType() == "invalid redirect of broken link"
-            || $redirect->getItemType() == "invalid redirect of shortened link") {
+        } else if (
+            $redirect->getItemType() == "invalid redirect of broken link"
+            || $redirect->getItemType() == "invalid redirect of shortened link"
+        ) {
 
             /* Validation of toLink */
 
@@ -456,7 +464,7 @@ class RedirectController extends AbstractController
         // Profiler retains every Doctrine query for the whole request; disable for large CSVs.
         $profiler?->disable();
         // Symfony + per-row UniqueEntity queries exceed the default 128M near ~750 rows.
-        // ini_set('memory_limit', '256M');
+        ini_set('memory_limit', '256M');
 
         $file = file($request->files->get('csv'));
 

--- a/src/Service/ProgramsService.php
+++ b/src/Service/ProgramsService.php
@@ -8,6 +8,7 @@ use App\Entity\Programs\ProgramWebsites;
 use App\Entity\Programs\ProgramKeywords;
 use Doctrine\Persistence\ManagerRegistry;
 use JetBrains\PhpStorm\ArrayShape;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -437,9 +438,11 @@ class ProgramsService
 	 * Flushes per created keyword (via createKeyword), and clears the EntityManager every
 	 * 50 processed rows so managed entities do not accumulate for large uploads.
 	 * @param array $rows
+	 * @param DebugDataHolder|null $debugDataHolder optional. In dev you get the holder and can $debugDataHolder->reset() after each batch. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
+	 * Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev.
 	 * @return array{created: string[], skipped: string[], rejected: int, linkSkipped: string[]}
 	 */
-	public function bulkCreateKeywords(array $rows): array
+	public function bulkCreateKeywords(array $rows, ?DebugDataHolder $debugDataHolder = null): array
 	{
 		$repository = $this->em->getRepository(ProgramKeywords::class);
 
@@ -465,7 +468,9 @@ class ProgramsService
 				$skipped[] = $keywordName;
 				$rowsSinceLastClear++;
 				if ($rowsSinceLastClear >= 50) {
+					// Clear EM + wipe debug query/backtrace buffer every 50 rows.
 					$this->em->clear();
+					$debugDataHolder?->reset();
 					$rowsSinceLastClear = 0;
 				}
 				continue;
@@ -488,12 +493,15 @@ class ProgramsService
 			$rowsSinceLastClear++;
 			if ($rowsSinceLastClear >= 50) {
 				// createKeyword() already flushes per row; clear to detach managed entities.
+				// Clear EM + wipe debug query/backtrace buffer every 50 rows.
 				$this->em->clear();
+				$debugDataHolder?->reset();
 				$rowsSinceLastClear = 0;
 			}
 		}
 
 		$this->em->clear();
+		$debugDataHolder?->reset();
 
 		return [
 			'created' => $created,


### PR DESCRIPTION
IT upped the PHP memory for ictest and ic from 64M to 128M. 

Autowired in doctrine's debug_data_holder to each bulkUploader function:

[Autowire(service: 'doctrine.debug_data_holder')] — Symfony doesn’t type-hint this service by default, so this attribute says “inject that specific service.”

@var DebugDataHolder $debugDataHolder = null — optional. In dev you get the holder and can $debugDataHolder->reset() after each batch. In prod the service often isn’t wired the same way, so $debugDataHolder is null and the ?->reset() calls no-op.
	 
Without that, every SQL query (plus backtrace) would pile up in memory for the whole upload request in dev. This does NOT affect prod. It would probably succeed with 128M without this so we can be sure larger CSVs will work even in dev without memory issues.